### PR TITLE
step3: add project status check target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 1%


### PR DESCRIPTION
This configuration tells Codecov to fail a status check if 100% of the codebase is not covered with tests. However, it also allows for a 1% threshold, meaning the true minimum is 99%.